### PR TITLE
param 1.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ test:
     - pytest
     - pytest-cov
     - flake8
+  source_files:
+    - tests
   commands:
     - pip check
     - pytest tests --cov=numbergen --cov=param --cov-append --cov-report xml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "param" %}
-{% set version = "1.11.1" %}
+{% set version = "1.12.0" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 source:
   fn: param-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/p/param/param-{{ version }}.tar.gz
-  sha256: b9857df01495bd55ddafb214fd1ed017d20699ce42ec2a0fd190d99caa03099f
+  sha256: 35d0281c8e3beb6dd469f46ff0b917752a54bed94d1b0c567346c76d0ff59c4a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,11 +34,8 @@ test:
     - pytest
     - pytest-cov
     - flake8
-  source_files:
-    - tests
   commands:
     - pip check
-    - pytest tests --cov=numbergen --cov=param --cov-append --cov-report xml
 
 about:
   home: http://ioam.github.io/param/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=2.7
 
@@ -27,6 +29,14 @@ test:
   imports:
     - param
     - numbergen
+  requires:
+    - pip
+    - pytest
+    - pytest-cov
+    - flake8
+  commands:
+    - pip check
+    - pytest tests --cov=numbergen --cov=param --cov-append --cov-report xml
 
 about:
   home: http://ioam.github.io/param/


### PR DESCRIPTION
Update param to 1.12.0

Version change: bump version number from 1.11.1 to 1.12.0
Bug Tracker: new open issues https://github.com/ioam/param/issues
Github releases: https://github.com/ioam/param/releases
Upstream setup.py: https://github.com/holoviz/param/blob/v1.12.0/setup.py

The package param is mentioned inside the packages:
colorcet | datashader | geoviews | geoviews-core | holoviews | hvplot | lancet | panel | pyct | pyct-core | pyspark | pyviz_comms | 

Actions:

1. Add missing packages: `setuptools`, `wheel`
2. Add test/requires
3. Add `pip check`

Result:
- all-succeeded