### PR TITLE
param 1.12.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "param" %}
-{% set version = "1.12.0" %}
+{% set version = "1.12.2" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 source:
   fn: param-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/p/param/param-{{ version }}.tar.gz
-  sha256: 35d0281c8e3beb6dd469f46ff0b917752a54bed94d1b0c567346c76d0ff59c4a
+  sha256: f9ccc45c7f329150fc3dca517b4595859199aa08d9cda2ecdebc112bbe718c0f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,15 +5,12 @@ package:
   name: {{ name|lower }}
   version: {{ version }}
 
-
 source:
-  fn: param-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/p/param/param-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: f9ccc45c7f329150fc3dca517b4595859199aa08d9cda2ecdebc112bbe718c0f
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -23,7 +20,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=2.7
+    - python
 
 test:
   imports:
@@ -31,14 +28,11 @@ test:
     - numbergen
   requires:
     - pip
-    - pytest
-    - pytest-cov
-    - flake8
   commands:
     - pip check
 
 about:
-  home: http://ioam.github.io/param/
+  home: https://param.holoviz.org/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
@@ -49,8 +43,8 @@ about:
     dynamically generated values, documentation strings, default
     values, etc., each of which is inherited from parent classes
     if not specified in a subclass.
-  doc_url: https://param.pyviz.org/
-  dev_url: https://github.com/ioam/param
+  doc_url: https://param.holoviz.org/
+  dev_url: https://github.com/holoviz/param
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Jira ticket:** [PKG-653](https://anaconda.atlassian.net/browse/PKG-653) (param-1.12.2)

**The upstream data:**
Github releases:  https://github.com/ioam/param/releases
[Diff between the latest and previous upstream releases](https://github.com/ioam/param/compare/1.12.0...1.12.2)
Requirements:
 * setup.cfg:  https://github.com/ioam/param/blob/v1.12.2/setup.cfg
 * setup.py:  https://github.com/ioam/param/blob/v1.12.2/setup.py

**_Actions:_**

1. Remove n`oarch: python`
2. Fix `python` in `run`
3. Update `test/requires`
4. Update `home`, `doc_url`, & `dev_url`

**_Notes:_**
 * It's a dependency for datashader, holoviews, geoviews, panel, pyct.

**Package's statistics**
<details>

 * Priority B | effort: easy | Category: anaconda_affiliated | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.12.2
 * Release on PyPi:
    * version: 1.12.2
    * date: 2022-06-20T17:29:06
* [PyPi history](https://pypi.org/project/param/#history)
 * Popularity: 
    * 3 months downloads: 193898.0
Key is not found. 0

</details>

**Other checks:**

<details>

6. - [x] Check the pinnings
11. - [x] Verify that the `build_number` is correct
12. - [x] has `setuptools`
13. - [x] has `wheel`
14. - [x] `pip` in test
15. - [x] Verify the test section
16. - [x] Verify if the package is `architecture specific`
17. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
18.  - [x] license_file: LICENSE.txt is present
19. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

20. - [x] license_family BSD is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/param-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/param-feedstock/tree/1.12.2)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/param)
* [Diff between upstream and feature branch](https://github.com/conda-forge/param-feedstock/compare/main...AnacondaRecipes:1.12.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/param-feedstock/compare/master...AnacondaRecipes:1.12.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/param-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.12.2 git@github.com:AnacondaRecipes/param-feedstock.git
```
