### PR TITLE
Release 2.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "param" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a7b30b08b547e2b78b02aeba6ed34e3c6a638f8e4824a76a96ffa2d7cf57e71f
+  sha256: 3b1da14abafa75bfd908572378a58696826b3719a723bc31b40ffff2e9a5c852
 
 build:
   number: 0


### PR DESCRIPTION
param 2.1.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/[param](https://github.com/holoviz/param))
- [Upstream changelog/diff](https://github.com/holoviz/param/compare/v2.1.0...v2.1.1#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)

### Explanation of changes:

- Patch release of Param, no change to the build or dependencies.
