### PR TITLE
Release 2.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "param" %}
-{% set version = "2.1.1" %}
+{% set version = "2.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3b1da14abafa75bfd908572378a58696826b3719a723bc31b40ffff2e9a5c852
+  sha256: 2ef63ef7aef37412eeb8ee3a06189a51f69c58c068824ae070baecb5b2abd0b8
 
 build:
   number: 0


### PR DESCRIPTION
param 2.2.0

**Destination channel:** defaults

### Links

- ~~[{ticket_number}]() ~~
- [Upstream repository](https://github.com/holoviz/param)
- [Upstream changelog/diff](https://github.com/holoviz/param/compare/v2.1.1...v2.2.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)

### Explanation of changes:

- Minor release, only dependency change is that the package dropped support for Python 3.8.
