### PR TITLE
2.3.0 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: b7e2b9c1d308d93c641937330990e8254aef479682c930b36ab681c4587d999a
 
 build:
+  # trigger 1
   number: 0
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv


### PR DESCRIPTION
Rebuilding because of CI issues after merging the PR https://github.com/AnacondaRecipes/param-feedstock/pull/14 (the release nd graph weren't created). v2.3.0 has never been uploaded to the main channel.
That's why we don't update the build number.