### PR TITLE
Update version to 2.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
     - pip check
 
 about:
-  home: https://param.holoviz.org
+  home: https://param.holoviz.org/en/docs/latest/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
@@ -52,7 +52,7 @@ about:
     These capabilities power HoloViz projects like Panel and HoloViews,
     making Param a solid foundation for building validated,
     introspectable, and responsive libraries and applications.
-  doc_url: https://param.holoviz.org
+  doc_url: https://param.holoviz.org/en/docs/latest/
   dev_url: https://github.com/holoviz/param
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "param" %}
-{% set version = "2.3.2" %}
+{% set version = "2.4.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ec70669bda9a3c13491098e7f5b640f60022b58b2f5bc7997099d54ea237d1de
+  sha256: 364a33bd8a968b053d8a49d319af78dc31b3ccb9661ecb95c29a3ea509d7e443
 
 build:
   number: 0


### PR DESCRIPTION
param 2.4.1

**Destination channel:** defaults

### Links

- [Upstream repository](github.com/holoviz/param)
- [Upstream changelog/diff](https://github.com/holoviz/param/compare/v2.3.3...v2.4.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)

### Explanation of changes:

- No dependency change since 2.3
